### PR TITLE
Added defensive CSS rules for use with Foundation CSS

### DIFF
--- a/Resources/views/Profiler/toolbar_style.html.twig
+++ b/Resources/views/Profiler/toolbar_style.html.twig
@@ -17,6 +17,12 @@
         bottom: 0;
         border-top: 1px solid #bbb;
     }
+    
+    .sf-toolbarreset span, 
+    .sf-toolbarreset div {
+        font-size: 11px;
+    }
+
     .sf-toolbarreset img {
         width: auto;
         display: inline;
@@ -103,6 +109,11 @@
         vertical-align: middle;
         min-width: 6px;
         min-height: 13px;
+    }
+
+    .sf-toolbar-block .sf-toolbar-status abbr {
+        color: #fff;
+        border-bottom: 1px dotted black;
     }
 
     .sf-toolbar-block .sf-toolbar-status-green {


### PR DESCRIPTION
CSS frameworks like Foundation and Twitter Bootstrap have rules which make it past the reset used by the debug bar. This commit adds fixes  specifically for Foundation CSS.

Here's what it looked like before the fix (click for full size): 
![broken bar](http://s11.postimage.org/ymeq2u3bn/Screen_shot_2012_08_13_at_11_12_46_AM.png)
