### PR TITLE
[Translation] improve extendability of metrics

### DIFF
--- a/Resources/views/Collector/translation.html.twig
+++ b/Resources/views/Collector/translation.html.twig
@@ -59,14 +59,16 @@
     <h2>Translation</h2>
 
     <div class="metrics">
-        <div class="metric">
-            <span class="value">{{ collector.locale|default('-') }}</span>
-            <span class="label">Locale</span>
-        </div>
-        <div class="metric">
-            <span class="value">{{ collector.fallbackLocales|join(', ')|default('-') }}</span>
-            <span class="label">Fallback locale{{ collector.fallbackLocales|length != 1 ? 's' }}</span>
-        </div>
+        {% block metrics %}    
+            <div class="metric">
+                <span class="value">{{ collector.locale|default('-') }}</span>
+                <span class="label">Locale</span>
+            </div>
+            <div class="metric">
+                <span class="value">{{ collector.fallbackLocales|join(', ')|default('-') }}</span>
+                <span class="label">Fallback locale{{ collector.fallbackLocales|length != 1 ? 's' }}</span>
+            </div>
+        {% endblock %}
     </div>
 
     <h2>Messages</h2>


### PR DESCRIPTION
For https://github.com/php-translation/symfony-bundle/issues/295 the organization would like to make better use of the extendability of the bundle's Twig templates.

This PR wraps the metrics in a block in order to add metrics. 

RfC: Another future enhancement would have to do with the extendability of the table, but the plan of approach for that (as it's rendered by a macro) has not been decided yet.