### PR TITLE
add an information about the last twig template used in the toolbar

### DIFF
--- a/Resources/views/Collector/twig.html.twig
+++ b/Resources/views/Collector/twig.html.twig
@@ -25,6 +25,15 @@
             <b>Macro Calls</b>
             <span class="sf-toolbar-status">{{ collector.macrocount }}</span>
         </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Last Template</b>
+            <span>
+                {% for template, count in collector.templates|slice(0,1) %}
+                    {%- set file = collector.templatePaths[template]|default(false) -%}
+                    {{ file|file_relative|default(file) }}
+                {% endfor %}
+            </span>
+        </div>
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}


### PR DESCRIPTION
Hi,

I propose a small modification of the debug toolbar :

When I'm working on a symfony project for a client, I'm often given an URL and asked "add this to this page, delete this" etc...
In the debug toolbar, I have almost all the infos I need : I can view the controller, the action and the route name instantly. But I can't view the twig template. For this I need to open the profiler in the twig sections to have this information.

I think that it would be nice to have it directly in the toolbar. Here's a little modification to have the twig template path in the toolbar, in the twig section.

![image](https://user-images.githubusercontent.com/35108257/64232675-afe5ef00-cef2-11e9-9232-cf41c62fd70d.png)

Thank you,
Lilian DI ROSA