### PR TITLE
Update results.html.twig

### DIFF
--- a/Resources/views/Profiler/results.html.twig
+++ b/Resources/views/Profiler/results.html.twig
@@ -33,7 +33,7 @@
             </thead>
             <tbody>
                 {% for result in tokens %}
-                    {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
+                    {% set css_class = (result.status_code|default(0) * 1) > 399 ? 'status-error' : (result.status_code|default(0) * 1) > 299 ? 'status-warning' : 'status-success' %}
 
                     <tr>
                         <td class="text-center">


### PR DESCRIPTION
I recently tested php 7.3 and wondered, why the status color in the results was inverted. So when i got a status code 400, the color was green, and everything with 200 was red. I'm currently unable to say, if it's actually the php version and if there were recent changes with comparisons. As i understand it, php casts strings to numbers, if compared with a number.

So i really don't know why it fails here, but in fact result.status_code is a string, and multiplying it with 1 casts it to a number, and then the right css style is applied.