### PR TITLE
Fix Unknown empty filter issue

### DIFF
--- a/Resources/views/Collector/mailer.html.twig
+++ b/Resources/views/Collector/mailer.html.twig
@@ -64,7 +64,7 @@
 {% block menu %}
     {% set events = collector.events %}
 
-    <span class="label {{ events.messages|empty ? 'disabled' }}">
+    <span class="label {{ events.messages is empty ? 'disabled' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>E-mails</strong>


### PR DESCRIPTION
Make use of the `is` operator instead of falsely using `empty` as a filter.