### PR TITLE
fix query explanation table width restrictions

### DIFF
--- a/Resources/views/Profiler/profiler.css.twig
+++ b/Resources/views/Profiler/profiler.css.twig
@@ -1234,7 +1234,10 @@ tr.log-status-silenced {
 }
 .sql-explain {
     overflow-x: auto;
-    max-width: 920px;
+    max-width: 888px;
+}
+.width-full .sql-explain {
+    max-width: min-content;
 }
 .sql-explain table td, .sql-explain table tr {
     word-break: normal;


### PR DESCRIPTION
max width was too wide for Normal page width
max width was too narrow for Full-page