### PR TITLE
Fix spelling of e-mails

### DIFF
--- a/Resources/views/Collector/mailer.html.twig
+++ b/Resources/views/Collector/mailer.html.twig
@@ -41,11 +41,11 @@
 
 {% block panel %}
     {% set events = collector.events %}
-    <h2>Emails</h2>
+    <h2>E-mails</h2>
 
     {% if not events.messages|length %}
         <div class="empty empty-panel">
-            <p>No emails were sent.</p>
+            <p>No e-mails were sent.</p>
         </div>
     {% else %}
         <div class="metrics">


### PR DESCRIPTION
Use correct spelling for e-mails and also make it equal to the menu

![image](https://user-images.githubusercontent.com/3579090/204300390-e413b50d-7657-4234-bbff-da015b095830.png)
