### PR TITLE
Remove XDEBUG_SESSION cookie while performing XHRs

### DIFF
--- a/Resources/views/Profiler/toolbar_js.html.twig
+++ b/Resources/views/Profiler/toolbar_js.html.twig
@@ -77,7 +77,34 @@
                 });
             }
 
+            const setCookie = function (name, value, days) {
+                var exp = new Date();
+                exp.setTime(exp.getTime() + (days * 24 * 60 * 60 * 1000));
+                document.cookie = name + '=' + value + '; expires=' + exp.toGMTString() + '; path=/; SameSite=Lax';
+            };
+
+            const getCookie = function (name) {
+                var prefix = name + '=';
+                var cookieStartIndex = document.cookie.indexOf(prefix);
+                var cookieEndIndex;
+
+                if (cookieStartIndex == -1) {
+                    return null;
+                }
+
+                cookieEndIndex = document.cookie.indexOf(';', cookieStartIndex + prefix.length);
+                if (cookieEndIndex == -1) {
+                    cookieEndIndex = document.cookie.length;
+                }
+
+                return unescape(document.cookie.substring(cookieStartIndex + prefix.length, cookieEndIndex));
+            };
+
             var request = function(url, onSuccess, onError, payload, options, tries) {
+                if (xdebugCookieValue !== null) {
+                    setCookie('XDEBUG_SESSION', xdebugCookieValue, 365);
+                }
+
                 var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
                 options = options || {};
                 options.retry = options.retry || false;
@@ -112,6 +139,11 @@
 
                 if (options.onSend) {
                     options.onSend(tries);
+                }
+
+                var xdebugCookieValue = getCookie('XDEBUG_SESSION');
+                if (xdebugCookieValue !== null) {
+                    setCookie('XDEBUG_SESSION', null, -1);
                 }
 
                 xhr.send(payload || '');


### PR DESCRIPTION
When using an Xdebug browser extension with Symfony, toolbar requests are also processed by Xdebug because the browser extension has set the XDEBUG_SESSION cookie on the page. This leads to superfluous breakpoint triggering when debugging at lower levels of the codebase, as well as a performance hit with no gain for every toolbar request.

The only sane way to prevent this behavior seems to be for the cookie to never be sent, as Xdebug has no mechanism for ignoring requests to certain URIs, and detecting this condition at the webserver and rewriting the request before passing it off to PHP is also non-trivial.

This PR detects the XDEBUG_SESSION cookie and removes it before conducting XHR, then re-sets it after the fact.

Thanks!